### PR TITLE
add lc_headers option to http_request to leave header names lowercase

### DIFF
--- a/HTTP.pm
+++ b/HTTP.pm
@@ -869,7 +869,7 @@ sub http_request($$@) {
       # send request
       $hdl->push_write (
          "$method $rpath HTTP/1.1\015\012"
-         . (join "", map "\u$_: $hdr{$_}\015\012", grep defined $hdr{$_}, keys %hdr)
+         . (join "", map { ($arg{lc_headers} ? $_ : "\u$_").": $hdr{$_}\015\012" } grep defined $hdr{$_}, keys %hdr)
          . "\015\012"
       );
       if (UNIVERSAL::isa($arg{body}, 'GLOB')) {


### PR DESCRIPTION
Наткнулись на сервис, чувствительный к регистру заголовков